### PR TITLE
feat: reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# Use the official Node.js 20 image as the base image
+FROM node:20-bookworm-slim as backend_builder
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the package.json and package-lock.json files to the container
+COPY backend/package*.json ./
+
+# Install the app dependencies
+RUN npm install
+
+# Copy the rest of the application code to the container
+COPY backend .
+
+RUN npm run build
+
+
+FROM node:20-bookworm-slim as frontend_builder
+
+WORKDIR /app
+
+COPY frontend/package*.json ./
+
+# Install the app dependencies
+RUN npm install
+
+COPY frontend .
+
+RUN npm run build
+
+FROM node:20-bookworm-slim  as runner
+# Expose the port on which the app will run
+
+WORKDIR /app
+
+COPY --from=backend_builder /app/build/index.js .
+COPY --from=frontend_builder /app/build ./www
+
+EXPOSE 3000
+# Start the app
+CMD [ "node", "index.js" ]

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@types/express": "^4.17.21",
         "@types/node": "^20.11.16",
+        "@vercel/ncc": "^0.38.1",
         "typescript": "^5.3.3"
       }
     },
@@ -113,6 +114,15 @@
         "@types/http-errors": "*",
         "@types/mime": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/accepts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,11 +9,13 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.16",
+    "@vercel/ncc": "^0.38.1",
     "typescript": "^5.3.3"
   },
   "scripts": {
     "start": "node .",
-    "dev": "npx tsc && node ."
+    "dev": "npx tsc && node .",
+    "build": "ncc build src/index.ts -o build"
   },
   "author": "Ipmake",
   "license": "ISC",


### PR DESCRIPTION
reduce docker image size from 1.1GB to 220 MB by
compile backend into single one js file using @vercel/ncc which also improves server startup performance when comes with a lot of dependencies, there is no need bundle with project node_modules directory
use 20:bookwrom-slim as base image which make the difference from 1.1GB to 220 MB
