### PR TITLE
feat: use caddy as static server to reduce image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,29 @@
+{
+  auto_https off
+}
+
+:3000 {
+  encode zstd gzip
+
+    handle /server {
+        respond {env.PLEX_SERVER} 200 
+    }
+
+	handle {
+		root * /app/www
+		try_files {path} /index.html
+		file_server
+
+        handle /index.html {
+            header Cache-Control no-cache
+            header Access-Control-Allow-Origin *
+            header Access-Control-Allow-Methods "GET, POST, PUT, DELETE"
+          }
+
+          handle {
+            header Cache-Control max-age=2592000
+            header Access-Control-Allow-Origin *
+            header Access-Control-Allow-Methods GET, POST, PUT, DELETE
+          }
+	}
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,29 +1,32 @@
 {
-  auto_https off
+	auto_https off
+	admin off
+	http_port 3000
+    https_port 3001
 }
 
 :3000 {
-  encode zstd gzip
+	encode zstd gzip
 
-    handle /server {
-        respond {env.PLEX_SERVER} 200 
-    }
+	handle /server {
+		respond {env.PLEX_SERVER} 200
+	}
 
 	handle {
 		root * /app/www
 		try_files {path} /index.html
 		file_server
 
-        handle /index.html {
-            header Cache-Control no-cache
-            header Access-Control-Allow-Origin *
-            header Access-Control-Allow-Methods "GET, POST, PUT, DELETE"
-          }
+		handle /index.html {
+			header Cache-Control no-cache
+			header Access-Control-Allow-Origin *
+			header Access-Control-Allow-Methods "GET, POST, PUT, DELETE"
+		}
 
-          handle {
-            header Cache-Control max-age=2592000
-            header Access-Control-Allow-Origin *
-            header Access-Control-Allow-Methods GET, POST, PUT, DELETE
-          }
+		handle {
+			header Cache-Control max-age=2592000
+			header Access-Control-Allow-Origin *
+			header Access-Control-Allow-Methods GET, POST, PUT, DELETE
+		}
 	}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-bookworm-slim as frontend_builder
+
+WORKDIR /app
+
+COPY frontend/package*.json ./
+
+# Install the app dependencies
+RUN npm install
+
+COPY frontend .
+
+RUN npm run build
+
+FROM caddy  as runner
+# Expose the port on which the app will run
+
+WORKDIR /app
+
+COPY Caddyfile /etc/caddy/Caddyfile
+
+COPY --from=frontend_builder /app/build ./www
+
+EXPOSE 3000
+# Start the app


### PR DESCRIPTION
reduce image size from 1.1GB to 52MB with caddy
currently backend works only like a http static file server and an endpoint return plex_server address for frontend
backend can be replace with caddy which is much simpler and small