### PR TITLE
feat: upgrade runner image to debian:bookworm-silm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm run build
 
 # /// Runner ///
 
-FROM debian:buster-slim as runner
+FROM debian:bookworm-slim as runner
 
 # Install dependencies for caddy
 RUN apt-get update && apt install -y \


### PR DESCRIPTION
upgrade runner image from debian:buster-slim to debian:bookworm-silm.
buster is near its eof according to debian offcial website [Buster](https://www.debian.org/releases/buster/)