### PR TITLE
Fixed the videos in the hero banner not taking the whole height/width

### DIFF
--- a/frontend/src/components/HeroDisplay.tsx
+++ b/frontend/src/components/HeroDisplay.tsx
@@ -77,7 +77,7 @@ function HeroDisplay({ item }: { item: Plex.Metadata }) {
           bottom: "20vh",
           opacity: previewVidURL ? 1 : 0,
           transition: "all 1s ease",
-          zIndex: 1000,
+          zIndex: 2,
           cursor: "pointer",
           pointerEvents: "all",
 


### PR DESCRIPTION
Added an objectFit: cover to the HeroDisplay Component so that the videos takes the whole space, also moved the z-index property as it was no being applied when not directly on the video component.